### PR TITLE
Added support for hugeint

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -23,6 +23,7 @@ const (
 	mdb_SMALLINT  = "smallint" // 16 bit integer
 	mdb_INT       = "int"      // 32 bit integer
 	mdb_BIGINT    = "bigint"   // 64 bit integer
+	mdb_HUGEINT   = "hugeint"  // 64 bit integer
 	mdb_SERIAL    = "serial"   // special 64 bit integer sequence generator
 	mdb_REAL      = "real"     // 32 bit floating point
 	mdb_DOUBLE    = "double"   // 64 bit floating point
@@ -207,6 +208,7 @@ var toGoMappers = map[string]toGoConverter{
 	mdb_INT:            toInt32,
 	mdb_WRD:            toInt32,
 	mdb_BIGINT:         toInt64,
+	mdb_HUGEINT:        toInt64,
 	mdb_SERIAL:         toInt64,
 	mdb_REAL:           toFloat,
 	mdb_DOUBLE:         toDouble,

--- a/converter_test.go
+++ b/converter_test.go
@@ -63,6 +63,7 @@ func TestConvertToGo(t *testing.T) {
 		tc{"32", "mediumint", int32(32)},
 		tc{"64", "bigint", int64(64)},
 		tc{"64", "longint", int64(64)},
+		tc{"64", "hugeint", int64(64)},
 		tc{"64", "serial", int64(64)},
 		tc{"3.2", "float", float32(3.2)},
 		tc{"3.2", "real", float32(3.2)},


### PR DESCRIPTION
Monetdb has a data type called hugeint. Wanted to support that in the repo


HUGEINT | 128 bit signed integer between -2127 +1 and +2127 -1 (±170141183460469231731687303715884105727)Note: HUGEINT is only available on platforms with a C-compiler that supports the __int128 or __int128_t data type (e.g., recent gcc, clang, & icc on Linux or MacOS X) and from Jul2015 release onwards
-- | --


